### PR TITLE
Remove colorize gem to simplify distribution

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,5 @@
 source "https://rubygems.org"
 
-gem "colorize"
-
 group :development, :test do
   gem "byebug"
   gem "rspec"

--- a/lib/hound.rb
+++ b/lib/hound.rb
@@ -1,10 +1,10 @@
-require "colorize"
 require "delegate"
 require "json"
 require "yaml"
 
 require "hound/version"
 require "hound/config"
+require "hound/format"
 require "hound/linters/base"
 require "hound/linters/ruby"
 require "hound/linters/javascript"

--- a/lib/hound/format.rb
+++ b/lib/hound/format.rb
@@ -1,0 +1,7 @@
+module Hound
+  module Format
+    def self.error(text)
+      "\e[31m#{text}\e[0m"
+    end
+  end
+end

--- a/lib/hound/linters/base.rb
+++ b/lib/hound/linters/base.rb
@@ -23,14 +23,15 @@ module Hound
         options["config_file"]
       end
 
-      def handle_config_errors
+      def parse_config_result &parse_command
         if filepath
-          yield
+          parse_command.call(file_content)
+          "Using #{filepath}"
         else
           "Not provided -- using default"
         end
       rescue Errno::ENOENT
-        "#{filepath} does not exist".colorize(:red)
+        Format.error("#{filepath} does not exist")
       end
 
       private
@@ -39,6 +40,10 @@ module Hound
 
       def enabled?
         options.fetch("enabled", true)
+      end
+
+      def file_content
+        File.read(filepath)
       end
 
       def options

--- a/lib/hound/linters/javascript.rb
+++ b/lib/hound/linters/javascript.rb
@@ -2,18 +2,9 @@ module Hound
   module Linter
     class Javascript < SimpleDelegator
       def config
-        handle_config_errors do
-          parse_config
-        end
-      end
-
-      private
-
-      def parse_config
-        JSON.parse(File.read(filepath))
-        "Using #{filepath}"
+        parse_config_result { |file_content| JSON.parse(file_content) }
       rescue JSON::ParserError
-        "#{filepath} is invalid JSON".colorize(:red)
+        Format.error("#{filepath} is invalid JSON")
       end
     end
   end

--- a/lib/hound/linters/ruby.rb
+++ b/lib/hound/linters/ruby.rb
@@ -2,18 +2,9 @@ module Hound
   module Linter
     class Ruby < SimpleDelegator
       def config
-        handle_config_errors do
-          parse_config
-        end
-      end
-
-      private
-
-      def parse_config
-        YAML.load(File.read(filepath))
-        "Using #{filepath}"
+        parse_config_result { |file_content| YAML.load(file_content) }
       rescue Psych::SyntaxError
-        "#{filepath} is invalid YAML".colorize(:red)
+        Format.error("#{filepath} is invalid YAML")
       end
     end
   end

--- a/spec/hound_spec.rb
+++ b/spec/hound_spec.rb
@@ -32,9 +32,11 @@ describe Hound do
         stub_file ".hound.yml", <<-CONFIG
           ruby:
             enabled: true
+            config_file: .ruby-style.yml
           go:
             enabled: false
         CONFIG
+        stub_file(".ruby-style.yml", "").and_raise(Errno::ENOENT)
 
         result = Hound.config
 
@@ -42,7 +44,7 @@ describe Hound do
 Ruby
 ---------
   Status: Enabled
-  Config: Not provided -- using default
+  Config: \e[31m.ruby-style.yml does not exist\e[0m
 
 Javascript
 ---------


### PR DESCRIPTION
Why:
- Having Colorize be a dependency makes distributing via Homebrew
  more difficult. We only use one color, so implement a simple formatter
  instead.
- Refactor to cover the case when output is colored.
